### PR TITLE
Preserve notifier parameters on escaping errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Preserve scoped notifier parameters on errors that are reported after `with_parameters` blocks have unwound.
 - Pin net-imap to ~> 0.4.11 to keep appraisal bundles compatible with Ruby < 3.2.
 - Use delegate for ApplicationMigration#connection to satisfy RuboCop.
 - Replace delegate with explicit ApplicationMigration.connection to avoid argument errors.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    peak_flow_utils (0.1.25)
+    peak_flow_utils (0.1.26)
       active-record-transactioner
       array_enumerator
       bigdecimal

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ PeakFlowUtils::Notifier.configure(auth_token: "your-token")
 PeakFlowUtils::Notifier.notify(error: error)
 ```
 
+Errors that escape a `PeakFlowUtils::Notifier.with_parameters` block keep a snapshot of the scoped parameters. Later framework handlers, such as Sidekiq error handlers, can report the same error after the block has unwound and still include the captured context.
+
 ### Reporting Rails errors
 
 Add this to `config/peakflow.rb`:

--- a/lib/peak_flow_utils/notifier.rb
+++ b/lib/peak_flow_utils/notifier.rb
@@ -3,6 +3,8 @@ class PeakFlowUtils::Notifier
   class NotConfiguredError < RuntimeError; end
   class NotifyMessageError < RuntimeError; end
 
+  CAPTURED_PARAMETERS_INSTANCE_VARIABLE = :@peak_flow_utils_captured_parameters
+
   attr_reader :auth_token, :mutex, :parameters
 
   def self.configure(auth_token:)
@@ -45,6 +47,9 @@ class PeakFlowUtils::Notifier
 
     begin
       yield
+    rescue StandardError => e
+      ::PeakFlowUtils::Notifier.current.capture_parameters_for_error(e)
+      raise
     ensure
       ::PeakFlowUtils::Notifier.current.mutex.synchronize do
         current_parameters = ::PeakFlowUtils::Notifier.current.parameters.value
@@ -60,8 +65,22 @@ class PeakFlowUtils::Notifier
     @parameters = ::PeakFlowUtils::InheritedLocalVar.new({})
   end
 
-  def current_parameters(parameters: nil)
+  def capture_parameters_for_error(error)
+    return if error.instance_variable_defined?(CAPTURED_PARAMETERS_INSTANCE_VARIABLE)
+
+    error.instance_variable_set(CAPTURED_PARAMETERS_INSTANCE_VARIABLE, current_parameters)
+  end
+
+  def captured_parameters_for_error(error)
+    return unless error&.instance_variable_defined?(CAPTURED_PARAMETERS_INSTANCE_VARIABLE)
+
+    error.instance_variable_get(CAPTURED_PARAMETERS_INSTANCE_VARIABLE)
+  end
+
+  def current_parameters(error: nil, parameters: nil)
     hashes = current_parameters_hashes
+    captured_parameters = captured_parameters_for_error(error)
+    hashes << captured_parameters if captured_parameters
     hashes << parameters if parameters
 
     ::PeakFlowUtils::DeepMerger.execute!(hashes: hashes)
@@ -90,7 +109,7 @@ class PeakFlowUtils::Notifier
       error: error
     )
 
-    merged_parameters = current_parameters(parameters: parameters)
+    merged_parameters = current_parameters(error: error, parameters: parameters)
 
     uri = URI("https://www.peakflow.io/errors/reports")
 

--- a/lib/peak_flow_utils/version.rb
+++ b/lib/peak_flow_utils/version.rb
@@ -1,3 +1,3 @@
 module PeakFlowUtils
-  VERSION = "0.1.25".freeze
+  VERSION = "0.1.26".freeze
 end

--- a/spec/peak_flow_utils/notifier_spec.rb
+++ b/spec/peak_flow_utils/notifier_spec.rb
@@ -144,6 +144,99 @@ describe PeakFlowUtils::Notifier do
       expect(backtrace).not_to be_empty
     end
 
+    it "keeps scoped parameters when an error is notified after the scope unwound" do
+      captured_body = nil
+
+      expect_any_instance_of(Net::HTTP).to receive(:request) do |_https, request|
+        captured_body = JSON.parse(request.body)
+
+        instance_double(
+          Net::HTTPResponse,
+          body: JSON.generate(
+            bug_report_id: 451,
+            bug_report_instance_id: 452,
+            project_id: 453,
+            project_slug: "test-project",
+            url: "https://www.peakflow.io/something"
+          ),
+          code: "200"
+        )
+      end
+
+      error = nil
+
+      begin
+        PeakFlowUtils::Notifier.with_parameters(notification: {notification_id: "notification-1"}) do
+          PeakFlowUtils::Notifier.with_parameters(content_parser: {template_name: "Email template body"}) do
+            raise "late notify"
+          end
+        end
+      rescue => e # rubocop:disable Style/RescueStandardError
+        error = e
+      end
+
+      expect(notifier.current_parameters).to eq({})
+
+      notifier.notify(error:)
+
+      expect(captured_body.fetch("error").fetch("parameters")).to eq(
+        "content_parser" => {
+          "template_name" => "Email template body"
+        },
+        "extra_param" => "test",
+        "notification" => {
+          "notification_id" => "notification-1"
+        }
+      )
+    end
+
+    it "lets explicit notify parameters override captured error parameters" do
+      captured_body = nil
+
+      expect_any_instance_of(Net::HTTP).to receive(:request) do |_https, request|
+        captured_body = JSON.parse(request.body)
+
+        instance_double(
+          Net::HTTPResponse,
+          body: JSON.generate(
+            bug_report_id: 451,
+            bug_report_instance_id: 452,
+            project_id: 453,
+            project_slug: "test-project",
+            url: "https://www.peakflow.io/something"
+          ),
+          code: "200"
+        )
+      end
+
+      error = nil
+
+      begin
+        PeakFlowUtils::Notifier.with_parameters(content_parser: {result_keys: ["old"], template_name: "Captured template"}) do
+          raise "late notify"
+        end
+      rescue => e # rubocop:disable Style/RescueStandardError
+        error = e
+      end
+
+      notifier.notify(
+        error:,
+        parameters: {
+          content_parser: {
+            template_name: "Explicit template"
+          }
+        }
+      )
+
+      expect(captured_body.fetch("error").fetch("parameters")).to eq(
+        "content_parser" => {
+          "result_keys" => ["old"],
+          "template_name" => "Explicit template"
+        },
+        "extra_param" => "test"
+      )
+    end
+
     it "#notify_message" do
       expect(PeakFlowUtils::Notifier.current).to receive(:notify) do |args|
         error = args.fetch(:error)


### PR DESCRIPTION
Problem
- Errors reported by a later framework handler, such as Sidekiq, can lose scoped Peakflow debug params because with_parameters has already unwound.
- That makes nested Liquid/background-job failures hard to diagnose from Peakflow reports.

Fix
- Snapshot active notifier parameters onto an escaping StandardError before with_parameters cleanup runs.
- Merge captured exception parameters into later notify calls, while still allowing explicit notify parameters to override captured values.
- Bump the gem version to 0.1.26 and document the behavior.

Testing
- bundle exec rspec spec/peak_flow_utils/notifier_spec.rb
- bundle exec rubocop lib/peak_flow_utils/notifier.rb spec/peak_flow_utils/notifier_spec.rb lib/peak_flow_utils/version.rb
- git diff --check